### PR TITLE
Adding a new option '--timer'

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,18 @@ function add(key, value, postfix) {
   return key;
 }
 
+function addTimer(key, value){
+  if(value < 1){
+    key.push("00");
+  }else if(value < 10){
+    key.push("0"+value);
+    
+  }else {
+    key.push(""+value);
+  }
+  return key;
+}
+
 /*
 The datePrettyFormat function converts milliseconds to a human readible
 date output that corresponds to a specific format.
@@ -57,6 +69,15 @@ function datePrettyFormat(ms, opts) {
   if (opts.compact) {
     ret = add(ret, parsed.seconds, 's');
     return '~' + ret[0];
+  }
+
+  if (opts.timer && !opts.compact){
+    var retTimer = []
+    retTimer = addTimer(retTimer, parsed.hours);
+    retTimer = addTimer(retTimer, parsed.minutes);
+    retTimer = addTimer(retTimer, parsed.seconds);
+    return retTimer.join(":");
+
   }
 
   ret = add(ret, (ms / 1000 % 60).toFixed(secDecimalDigits).replace(/\.0$/, ''), 's');

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,30 @@ describe('date-difference', function() {
       assert.equal(dateDifference(date1, date2, {
         compact: true
       }), '~4h');
+    });
+
+    it('returns the difference between the two dates in timer format "00:00:00"', function() {
+      var date1 = new Date("2014-05-26T03:00:00");
+      var date2 = new Date("2015-05-27T07:08:07");
+
+      assert.equal(dateDifference(date1, date2, {
+        timer: true, compact:true
+      }), '~1y');
+
+      date1 = new Date("2015-01-25T12:00:00");
+      date2 = new Date("2015-03-05T04:01:23");
+
+      assert.equal(dateDifference(date1, date2, {
+        timer: true
+      }), '16:01:23');
+      
+
+      date1 = new Date("2015-04-25T12:00:00");
+      date2 = new Date("2015-04-25T16:01:23");
+
+      assert.equal(dateDifference(date1, date2, {
+        timer: true
+      }), '04:01:23');
     })
   })
 });


### PR DESCRIPTION
First all, this module has been really helpful for me. 
I have added a new option in order to show the difference of date in format _timer_ (`"00:00:00"`). 

Obviously, if `compact=true`, the option `timer` will be ignored
